### PR TITLE
esp-idf support (non-arduino)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "src/I2SClocklessLedDriver.cpp"
+    INCLUDE_DIRS "src"
+    REQUIRES driver
+)

--- a/src/I2SClocklessLedDriver.h
+++ b/src/I2SClocklessLedDriver.h
@@ -328,10 +328,10 @@ class I2SClocklessLedDriver {
   float _gammar, _gammab, _gammag, _gammaw, _gammaw2;
   bool extractWhiteFromRGB = true;  // 🌙
   intr_handle_t _gI2SClocklessDriver_intr_handle;
-  volatile xSemaphoreHandle I2SClocklessLedDriver_sem = NULL;
-  volatile xSemaphoreHandle I2SClocklessLedDriver_semSync = NULL;
-  volatile xSemaphoreHandle I2SClocklessLedDriver_semDisp = NULL;
-  volatile xSemaphoreHandle I2SClocklessLedDriver_waitDisp = NULL;
+  volatile SemaphoreHandle_t I2SClocklessLedDriver_sem = NULL;
+  volatile SemaphoreHandle_t I2SClocklessLedDriver_semSync = NULL;
+  volatile SemaphoreHandle_t I2SClocklessLedDriver_semDisp = NULL;
+  volatile SemaphoreHandle_t I2SClocklessLedDriver_waitDisp = NULL;
   volatile int dmaBufferActive = 0;
   volatile bool wait;
   displayMode __displayMode;
@@ -747,7 +747,7 @@ putdefaultones((uint16_t *)DMABuffersTampon[1]->buffer);
       return;
     }
     if (isDisplaying == true && dispmode == NO_WAIT) {
-      Serial.println("we are here");
+      // Serial.println("we are here");
       wasWaitingtofinish = true;
       if (I2SClocklessLedDriver_waitDisp == NULL) I2SClocklessLedDriver_waitDisp = xSemaphoreCreateCounting(10, 0);
       if (xSemaphoreTake(I2SClocklessLedDriver_waitDisp, pdMS_TO_TICKS(500)) == pdFALSE) {
@@ -896,7 +896,7 @@ putdefaultones((uint16_t *)DMABuffersTampon[1]->buffer);
     uint32_t total = 0;
     uint32_t posOnStrip = pos;
     if (pos > total_leds - 1) {
-      printf("Position out of bound %d > %d\n", pos, total_leds - 1);
+      printf("Position out of bound %lu > %lu\n", pos, total_leds - 1);
       return;
     }
     while (total <= pos) {

--- a/src/___pixeltypes.h
+++ b/src/___pixeltypes.h
@@ -2,7 +2,12 @@
 #ifdef USE_FASTLED
   #include "FastLED.h"
 #endif
+
+#ifdef ARDUINO
 #include "Arduino.h"
+#else
+#include "stdint.h"
+#endif
 
 #define _OUT_OF_BOUND -12
 


### PR DESCRIPTION
A few small changes to add esp-idf support.

- added a `CMakeLists.txt` for the esp-idf build system
- changed `xSemaphoreHandle` to `SemaphoreHandle_t`
- guarded `Arudino.h` (maybe its not even needed if using `stdint.h` is fine, but I dont know exactly the Arduino testing procedure so I left it in)